### PR TITLE
Fix WhisperX model loading and enable tests

### DIFF
--- a/pipeline.py
+++ b/pipeline.py
@@ -115,25 +115,24 @@ def transcribe_and_diarize(
     if device == "auto":
         device = "cuda" if torch.cuda.is_available() else "cpu"
 
-
     logging.info(
         "Loading WhisperX model %s on %s (%s)", asr_model, device, compute_type
-
-    logging.info("Loading WhisperX model %s on %s (%s)", asr_model, device, compute_type)
-    model = whisperx.load_model(
-        asr_model, device=device, compute_type=compute_type, cpu_threads=cpu_threads
-
     )
     try:
         model = whisperx.load_model(
-            asr_model, device=device, compute_type=compute_type, cpu_threads=cpu_threads
+            asr_model,
+            device=device,
+            compute_type=compute_type,
+            cpu_threads=cpu_threads,
         )
     except TypeError:
         logging.warning(
             "Installed whisperx does not support 'cpu_threads'; loading without it"
         )
         model = whisperx.load_model(
-            asr_model, device=device, compute_type=compute_type
+            asr_model,
+            device=device,
+            compute_type=compute_type,
         )
 
     asr_kwargs = {}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Summary
- fix transcribe_and_diarize to log and load WhisperX model correctly
- ensure tests can import project modules by adding tests/conftest

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedcf9f300832ca4ba19b88eb722d6