### PR TITLE
Fix WhisperX model loading and enable tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+import sys
+from pathlib import Path
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))


### PR DESCRIPTION
## Summary
- fix transcribe_and_diarize to log and load WhisperX model correctly
- ensure tests can import project modules by adding tests/conftest
- gracefully disable `vad_filter` when unsupported by installed WhisperX version

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68aedcf9f300832ca4ba19b88eb722d6